### PR TITLE
Netbsd: standard integer types are also defined as macros

### DIFF
--- a/src/unsigned_stubs.c
+++ b/src/unsigned_stubs.c
@@ -22,10 +22,9 @@
 
 #include "ocaml_integers.h"
 
-#define Uint_custom_val(TYPE, V) Uint_custom_val_(TYPE, V)
-#define Uint_custom_val_(TYPE, V) (TYPE ## _custom_val(TYPE, V))
-#define uint32_t_custom_val(TYPE, V) (*(TYPE*)(Data_custom_val(V)))
-#define uint64_t_custom_val(TYPE, V) (*(TYPE*)(Data_custom_val(V)))
+#define Uint_custom_val(SIZE, V) Uint_custom_val_(SIZE, V)
+#define Uint_custom_val_(SIZE, V) \
+  (*(uint ## SIZE ## _t *)(Data_custom_val(V)))
 
 #define TYPE(SIZE) uint ## SIZE ## _t
 #define BUF_SIZE(TYPE) ((sizeof(TYPE) * CHAR_BIT + 2) / 3 + 1)
@@ -34,28 +33,28 @@
   /* OP : t -> t -> t */                                                     \
   value integers_uint ## SIZE ## _ ## NAME(value a, value b)                 \
   {                                                                          \
-    return integers_copy_uint ## SIZE(Uint_custom_val(TYPE(SIZE), a)         \
-                                 OP Uint_custom_val(TYPE(SIZE), b));         \
+    return integers_copy_uint ## SIZE(Uint_custom_val(SIZE, a)               \
+                                 OP Uint_custom_val(SIZE, b));             \
   }
 
 #define UINT_DEFS(BITS, BYTES)                                               \
   static int uint ## BITS ## _cmp(value v1, value v2)                        \
   {                                                                          \
-    TYPE(BITS) u1 = Uint_custom_val(TYPE(BITS), v1);                         \
-    TYPE(BITS) u2 = Uint_custom_val(TYPE(BITS), v2);                         \
+    TYPE(BITS) u1 = Uint_custom_val(BITS, v1);                               \
+    TYPE(BITS) u2 = Uint_custom_val(BITS, v2);                               \
     return (u1 > u2) - (u1 < u2);                                            \
   }                                                                          \
                                                                              \
   static intnat uint ## BITS ## _hash(value v)                               \
   {                                                                          \
-    return Uint_custom_val(TYPE(BITS), v);                                   \
+    return Uint_custom_val(BITS, v);                                         \
   }                                                                          \
                                                                              \
   static void uint ## BITS ## _serialize(value v,                            \
                                          uintnat *wsize_32,                  \
                                          uintnat *wsize_64)                  \
   {                                                                          \
-    caml_serialize_int_ ## BYTES(Uint_custom_val(TYPE(BITS), v));            \
+    caml_serialize_int_ ## BYTES(Uint_custom_val(BITS, v));                  \
     *wsize_32 = *wsize_64 = BYTES;                                           \
   }                                                                          \
                                                                              \
@@ -78,7 +77,7 @@
   value integers_copy_uint ## BITS(TYPE(BITS) u)                             \
   {                                                                          \
     value res = caml_alloc_custom(&caml_uint ## BITS ## _ops, BYTES, 0, 1);  \
-    Uint_custom_val(TYPE(BITS), res) = u;                                    \
+    Uint_custom_val(BITS, res) = u;                                          \
     return res;                                                              \
   }                                                                          \
   UINT_PRIMOP(add, BITS,  +)                                                 \
@@ -91,8 +90,8 @@
   /* div : t -> t -> t */                                                    \
   value integers_uint ## BITS ## _div(value n_, value d_)                    \
   {                                                                          \
-    TYPE(BITS) n = Uint_custom_val(TYPE(BITS), n_);                          \
-    TYPE(BITS) d = Uint_custom_val(TYPE(BITS), d_);                          \
+    TYPE(BITS) n = Uint_custom_val(BITS, n_);                                \
+    TYPE(BITS) d = Uint_custom_val(BITS, d_);                                \
     if (d == (TYPE(BITS)) 0)                                                 \
         caml_raise_zero_divide();                                            \
     return integers_copy_uint ## BITS (n / d);                               \
@@ -101,8 +100,8 @@
   /* rem : t -> t -> t */                                                    \
   value integers_uint ## BITS ## _rem(value n_, value d_)                    \
   {                                                                          \
-    TYPE(BITS) n = Uint_custom_val(TYPE(BITS), n_);                          \
-    TYPE(BITS) d = Uint_custom_val(TYPE(BITS), d_);                          \
+    TYPE(BITS) n = Uint_custom_val(BITS, n_);                                \
+    TYPE(BITS) d = Uint_custom_val(BITS, d_);                                \
     if (d == (TYPE(BITS)) 0)                                                 \
         caml_raise_zero_divide();                                            \
     return integers_copy_uint ## BITS (n % d);                               \
@@ -111,14 +110,14 @@
   /* shift_left : t -> int -> t */                                           \
   value integers_uint ## BITS ## _shift_left(value a, value b)               \
   {                                                                          \
-    return integers_copy_uint ## BITS(Uint_custom_val(TYPE(BITS), a)         \
+    return integers_copy_uint ## BITS(Uint_custom_val(BITS, a)                 \
                                     << Int_val(b));                          \
   }                                                                          \
                                                                              \
   /* shift_right : t -> int -> t */                                          \
   value integers_uint ## BITS ## _shift_right(value a, value b)              \
   {                                                                          \
-    return integers_copy_uint ## BITS(Uint_custom_val(TYPE(BITS), a)         \
+    return integers_copy_uint ## BITS(Uint_custom_val(BITS, a)                 \
                                     >> Int_val(b));                          \
   }                                                                          \
                                                                              \
@@ -131,7 +130,7 @@
   /* to_int : t -> int */                                                    \
   value integers_uint ## BITS ## _to_int(value a)                            \
   {                                                                          \
-    return Val_int(Uint_custom_val(TYPE(BITS), a));                          \
+    return Val_int(Uint_custom_val(BITS, a));                                \
   }                                                                          \
                                                                              \
   /* of_int64 : int64 -> t */                                                \
@@ -143,7 +142,7 @@
   /* to_int64 : t -> int64 */                                                \
   value integers_uint ## BITS ## _to_int64(value a)                          \
   {                                                                          \
-    return caml_copy_int64(Uint_custom_val(TYPE(BITS), a));                  \
+    return caml_copy_int64(Uint_custom_val(BITS, a));                        \
   }                                                                          \
                                                                              \
   /* of_string : string -> t */                                              \
@@ -160,7 +159,7 @@
   value integers_uint ## BITS ## _to_string(value a)                         \
   {                                                                          \
     char buf[BUF_SIZE(TYPE(BITS))];                                          \
-    if (sprintf(buf, "%" PRIu ## BITS , Uint_custom_val(TYPE(BITS), a)) < 0) \
+    if (sprintf(buf, "%" PRIu ## BITS , Uint_custom_val(BITS, a)) < 0)       \
       caml_failwith("string_of_int");                                        \
     else                                                                     \
       return caml_copy_string(buf);                                          \
@@ -210,7 +209,7 @@ value integers_uint_size (value _) { return Val_int(sizeof (unsigned int)); }
 value integers_ulong_size (value _) { return Val_int(sizeof (unsigned long)); }
 value integers_ulonglong_size (value _) { return Val_int(sizeof (unsigned long long)); }
 value integers_uint32_of_int32 (value i) { return integers_copy_uint32(Int32_val(i)); }
-value integers_int32_of_uint32 (value u) { return caml_copy_int32(Uint_custom_val(uint32_t, u)); }
+value integers_int32_of_uint32 (value u) { return caml_copy_int32(Uint_custom_val(32, u)); }
 value integers_uintptr_t_size (value _) { return Val_int(sizeof (uintptr_t)); }
 value integers_intptr_t_size (value _) { return Val_int(sizeof (intptr_t)); }
 value integers_ptrdiff_t_size (value _) { return Val_int(sizeof (ptrdiff_t)); }


### PR DESCRIPTION
See https://github.com/ocamllabs/ocaml-ctypes/pull/453/

/cc @fdopen.

Fixes #8.