### PR TITLE
Add Unsigned.from_size and Signed.from_size

### DIFF
--- a/src/signed.ml
+++ b/src/signed.ml
@@ -119,15 +119,15 @@ external int_size : unit -> int = "integers_uint_size"
 external long_size : unit -> int = "integers_ulong_size"
 external llong_size : unit -> int = "integers_ulonglong_size"
 
-let pick : size:int -> (module S) =
-  fun ~size -> match size with
+let from_size : bytes:int -> (module S) =
+  fun ~bytes -> match bytes with
     | 4 -> (module Int32)
     | 8 -> (module Int64)
-    | _ -> assert false
+    | _ -> invalid_arg "Signed.from_size"
 
-module SInt = (val pick ~size:(int_size ()))
-module Long = (val pick ~size:(long_size ()))
-module LLong = (val pick ~size:(llong_size ()))
+module SInt = (val from_size ~bytes:(int_size ()))
+module Long = (val from_size ~bytes:(long_size ()))
+module LLong = (val from_size ~bytes:(llong_size ()))
 
 type sint = SInt.t
 type long = Long.t

--- a/src/signed.ml
+++ b/src/signed.ml
@@ -119,15 +119,14 @@ external int_size : unit -> int = "integers_uint_size"
 external long_size : unit -> int = "integers_ulong_size"
 external llong_size : unit -> int = "integers_ulonglong_size"
 
-let from_size : bytes:int -> (module S) =
-  fun ~bytes -> match bytes with
-    | 4 -> (module Int32)
-    | 8 -> (module Int64)
-    | _ -> invalid_arg "Signed.from_size"
+let of_byte_size : int -> (module S) = function
+  | 4 -> (module Int32)
+  | 8 -> (module Int64)
+  | _ -> invalid_arg "Signed.of_byte_size"
 
-module SInt = (val from_size ~bytes:(int_size ()))
-module Long = (val from_size ~bytes:(long_size ()))
-module LLong = (val from_size ~bytes:(llong_size ()))
+module SInt = (val of_byte_size (int_size ()))
+module Long = (val of_byte_size (long_size ()))
+module LLong = (val of_byte_size (llong_size ()))
 
 type sint = SInt.t
 type long = Long.t

--- a/src/signed.mli
+++ b/src/signed.mli
@@ -67,8 +67,8 @@ type long = Long.t
 type llong = LLong.t
 (** The signed long long integer type. *)
 
-val from_size : bytes:int -> (module S)
-(** [from_size ~bytes] is a module of type S that implements a signed type
-    with [bytes] bytes.
+val of_byte_size : int -> (module S)
+(** [of_byte_size b] is a module of type S that implements a signed type
+    with [b] bytes.
 
     Raise [Invalid_argument] if no suitable type is available. *)

--- a/src/signed.mli
+++ b/src/signed.mli
@@ -66,3 +66,9 @@ type long = Long.t
 
 type llong = LLong.t
 (** The signed long long integer type. *)
+
+val from_size : bytes:int -> (module S)
+(** [from_size ~bytes] is a module of type S that implements a signed type
+    with [bytes] bytes.
+
+    Raise [Invalid_argument] if no suitable type is available. *)

--- a/src/unsigned.ml
+++ b/src/unsigned.ml
@@ -230,13 +230,12 @@ struct
 end
 
 
-let from_size : bytes:int -> (module S) =
-  fun ~bytes -> match bytes with
-    | 1 -> (module UInt8)
-    | 2 -> (module UInt16)
-    | 4 -> (module UInt32)
-    | 8 -> (module UInt64)
-    | _ -> invalid_arg "Unsigned.from_size"
+let of_byte_size : int -> (module S) = function
+  | 1 -> (module UInt8)
+  | 2 -> (module UInt16)
+  | 4 -> (module UInt32)
+  | 8 -> (module UInt64)
+  | _ -> invalid_arg "Unsigned.of_byte_size"
 
       
 external size_t_size : unit -> int = "integers_size_t_size"
@@ -245,12 +244,12 @@ external uint_size : unit -> int = "integers_uint_size"
 external ulong_size : unit -> int = "integers_ulong_size"
 external ulonglong_size : unit -> int = "integers_ulonglong_size"
 
-module Size_t : S = (val from_size ~bytes:(size_t_size ()))
+module Size_t : S = (val of_byte_size (size_t_size ()))
 module UChar = UInt8
-module UShort : S = (val from_size ~bytes:(ushort_size ()))
-module UInt : S = (val from_size ~bytes:(uint_size ()))
-module ULong : S = (val from_size ~bytes:(ulong_size ()))
-module ULLong : S = (val from_size ~bytes:(ulonglong_size ()))
+module UShort : S = (val of_byte_size (ushort_size ()))
+module UInt : S = (val of_byte_size (uint_size ()))
+module ULong : S = (val of_byte_size (ulong_size ()))
+module ULLong : S = (val of_byte_size (ulonglong_size ()))
 
 type uchar = UChar.t
 type uint8 = UInt8.t

--- a/src/unsigned.ml
+++ b/src/unsigned.ml
@@ -230,13 +230,14 @@ struct
 end
 
 
-let pick : size:int -> (module S) =
-  fun ~size -> match size with
+let from_size : bytes:int -> (module S) =
+  fun ~bytes -> match bytes with
     | 1 -> (module UInt8)
     | 2 -> (module UInt16)
     | 4 -> (module UInt32)
     | 8 -> (module UInt64)
-    | _ -> assert false
+    | _ -> invalid_arg "Unsigned.from_size"
+
       
 external size_t_size : unit -> int = "integers_size_t_size"
 external ushort_size : unit -> int = "integers_ushort_size"
@@ -244,12 +245,12 @@ external uint_size : unit -> int = "integers_uint_size"
 external ulong_size : unit -> int = "integers_ulong_size"
 external ulonglong_size : unit -> int = "integers_ulonglong_size"
 
-module Size_t : S = (val pick ~size:(size_t_size ()))
+module Size_t : S = (val from_size ~bytes:(size_t_size ()))
 module UChar = UInt8
-module UShort : S = (val pick ~size:(ushort_size ()))
-module UInt : S = (val pick ~size:(uint_size ()))
-module ULong : S = (val pick ~size:(ulong_size ()))
-module ULLong : S = (val pick ~size:(ulonglong_size ()))
+module UShort : S = (val from_size ~bytes:(ushort_size ()))
+module UInt : S = (val from_size ~bytes:(uint_size ()))
+module ULong : S = (val from_size ~bytes:(ulong_size ()))
+module ULLong : S = (val from_size ~bytes:(ulonglong_size ()))
 
 type uchar = UChar.t
 type uint8 = UInt8.t

--- a/src/unsigned.mli
+++ b/src/unsigned.mli
@@ -192,3 +192,9 @@ type ulong = ULong.t
 
 type ullong = ULLong.t
 (** The unsigned long long integer type. *)
+
+val from_size : bytes:int -> (module S)
+(** [from_size ~bytes] is a module of type S that implements an unsigned type
+    with [bytes] bytes.
+
+    Raise [Invalid_argument] if no suitable type is available. *)

--- a/src/unsigned.mli
+++ b/src/unsigned.mli
@@ -193,8 +193,8 @@ type ulong = ULong.t
 type ullong = ULLong.t
 (** The unsigned long long integer type. *)
 
-val from_size : bytes:int -> (module S)
-(** [from_size ~bytes] is a module of type S that implements an unsigned type
-    with [bytes] bytes.
+val of_byte_size : int -> (module S)
+(** [of_byte_size b] is a module of type S that implements an unsigned type
+    with [b] bytes.
 
     Raise [Invalid_argument] if no suitable type is available. *)


### PR DESCRIPTION
`Unsigned.from_size ~bytes:b` is a module of type `Unsigned.S` that implements an unsigned type with `b` bytes.