### PR TITLE
Add "equal" and "pp" to the output signatures

### DIFF
--- a/src/signed.ml
+++ b/src/signed.ml
@@ -91,6 +91,7 @@ struct
   let of_nativeint = Nativeint.to_int
   let abs = Pervasives.abs
   let neg x = -x
+  let pp fmt n = Format.fprintf fmt "%d" n
 end
 
 module Int32 = 
@@ -104,6 +105,7 @@ struct
   let to_int64 = Int64.of_int32
   let max = Pervasives.max
   let min = Pervasives.min
+  let pp fmt n = Format.fprintf fmt "%ld" n
 end
 
 module Int64 = 
@@ -115,6 +117,7 @@ struct
   let to_int64 x = x
   let max = Pervasives.max
   let min = Pervasives.min
+  let pp fmt n = Format.fprintf fmt "%Ld" n
 end
 
 (* C guarantees that sizeof(t) == sizeof(unsigned t) *)

--- a/src/signed.ml
+++ b/src/signed.ml
@@ -79,6 +79,7 @@ struct
     let succ = Pervasives.succ
     let pred = Pervasives.pred
     let compare = Pervasives.compare
+    let equal = Pervasives.(=)
     let max = Pervasives.max
     let min = Pervasives.min
   end
@@ -94,6 +95,7 @@ end
 
 module Int32 = 
 struct
+  let equal (x:int32) (y:int32) = x = y
   include Int32
   module Infix = MakeInfix(Int32)
   let of_nativeint = Nativeint.to_int32
@@ -106,6 +108,7 @@ end
 
 module Int64 = 
 struct
+  let equal (x:int64) (y:int64) = x = y
   include Int64
   module Infix = MakeInfix(Int64)
   let of_int64 x = x

--- a/src/unsigned.ml
+++ b/src/unsigned.ml
@@ -41,6 +41,7 @@ module type Extras = sig
   val succ : t -> t
   val pred : t -> t
   val compare : t -> t -> int
+  val equal : t -> t -> bool
   val max : t -> t -> t
   val min : t -> t -> t
 end
@@ -94,6 +95,7 @@ struct
   let pred n = sub n one
   let lognot n = logxor n max_int
   let compare (x : t) (y : t) = Pervasives.compare x y
+  let equal (x : t) (y : t) = Pervasives.(=) x y
   let max (x : t) (y : t) = Pervasives.max x y
   let min (x : t) (y : t) = Pervasives.min x y
 end

--- a/src/unsigned.ml
+++ b/src/unsigned.ml
@@ -44,6 +44,7 @@ module type Extras = sig
   val equal : t -> t -> bool
   val max : t -> t -> t
   val min : t -> t -> t
+  val pp : Format.formatter -> t -> unit
 end
 
 
@@ -98,6 +99,7 @@ struct
   let equal (x : t) (y : t) = Pervasives.(=) x y
   let max (x : t) (y : t) = Pervasives.max x y
   let min (x : t) (y : t) = Pervasives.min x y
+  let pp fmt x = Format.fprintf fmt "%s" (to_string x)
 end
 
 

--- a/src/unsigned.mli
+++ b/src/unsigned.mli
@@ -92,6 +92,9 @@ module type S = sig
   val min : t -> t -> t
   (** [min x y] is the lesser of [x] and [y] *)
 
+  val pp : Format.formatter -> t -> unit
+  (** Output the result of {!to_string} on a formatter. *)
+
   module Infix : sig
     val (+) : t -> t -> t
     (** Addition.  See {!add}. *)

--- a/src/unsigned.mli
+++ b/src/unsigned.mli
@@ -83,6 +83,9 @@ module type S = sig
   (** The comparison function for unsigned integers, with the same
       specification as {!Pervasives.compare}. *)
 
+  val equal : t -> t -> bool
+  (** Tests for equality, with the same specification as {!Pervasives.(=)}. *)
+
   val max : t -> t -> t
   (** [max x y] is the greater of [x] and [y] *)
 


### PR DESCRIPTION
Hi!

This PR adds two functions to each module in this package, `equal` and `pp`. This makes `integers` compatible with `ppx_deriving`. For example the following code will do the right thing automatically:

```ocaml
type t =
  { x : bool
  ; y : Unsigned.UInt32.t
  }
  [@@deriving eq,show]
```

Adding to the output signatures is susceptible to break dependent packages. In particular, I submitted [a PR against ctypes](https://github.com/ocamllabs/ocaml-ctypes/pull/564) to be more resilient against this kind of breakage.

Thanks!