### PR TITLE
Expose Signed.S.Infix.(asr) (fix #16)

### DIFF
--- a/src/signed.ml
+++ b/src/signed.ml
@@ -8,7 +8,7 @@
 module Pervasives = Pervasives [@@ocaml.warning "-3"]
 
 module type S = sig
-  include Unsigned.S
+  include Unsigned.Operations
 
   val neg : t -> t
   val abs : t -> t
@@ -19,6 +19,12 @@ module type S = sig
   val to_nativeint : t -> nativeint
   val of_int64 : int64 -> t
   val to_int64 : t -> int64
+
+  module Infix : sig
+    include Unsigned.Infixes with type t := t
+
+    val (asr) : t -> int -> t
+  end
 end
 
 module type Basics = sig

--- a/src/signed.ml
+++ b/src/signed.ml
@@ -7,13 +7,16 @@
 
 module Pervasives = Pervasives [@@ocaml.warning "-3"]
 
+module type Infix = sig
+  type t
+  include Unsigned.Infix with type t := t
+  val (asr) : t -> int -> t
+end
+
 module type S = sig
   type t
 
-  module Infix : sig
-    include Unsigned.Infix with type t := t
-    val (asr) : t -> int -> t
-  end
+  module Infix : Infix with type t := t
 
   include Unsigned.S with type t := t
                      with module Infix := Infix

--- a/src/signed.mli
+++ b/src/signed.mli
@@ -7,15 +7,20 @@
 
 (** Types and operations for signed integers. *)
 
+module type Infix = sig
+  type t
+
+  include Unsigned.Infix with type t := t
+
+  val (asr) : t -> int -> t
+  (** [x asr y] shifts [x] to the right by [y] bits.  See {!shift_right}. *)
+end
+
+
 module type S = sig
   type t
 
-  module Infix : sig
-    include Unsigned.Infix with type t := t
-
-    val (asr) : t -> int -> t
-    (** [x asr y] shifts [x] to the right by [y] bits.  See {!shift_right}. *)
-  end
+  module Infix : Infix with type t := t
 
   include Unsigned.S with type t := t
                      with module Infix := Infix

--- a/src/signed.mli
+++ b/src/signed.mli
@@ -8,7 +8,7 @@
 (** Types and operations for signed integers. *)
 
 module type S = sig
-  include Unsigned.S
+  include Unsigned.Operations
 
   val neg : t -> t
   (** Unary negation. *)
@@ -37,6 +37,13 @@ module type S = sig
 
   val to_int64 : t -> int64
   (** Convert the given signed integer to an int64 value. *)
+
+  module Infix : sig
+    include Unsigned.Infixes with type t := t
+
+    val (asr) : t -> int -> t
+    (** [x lsr y] shifts [x] to the right by [y] bits.  See {!shift_right}. *)
+  end
 end
 (** Signed integer operations *)
 

--- a/src/unsigned.ml
+++ b/src/unsigned.ml
@@ -64,6 +64,12 @@ module type Infix = sig
   val (lsr) : t -> int -> t
 end
 
+module type Operations = sig
+  include Basics
+  include Extras with type t := t
+end
+
+module type Infixes = Infix
 
 module type S = sig
   include Basics

--- a/src/unsigned.mli
+++ b/src/unsigned.mli
@@ -7,7 +7,7 @@
 
 (** Types and operations for unsigned integers. *)
 
-module type S = sig
+module type Operations = sig
   type t
 
   val add : t -> t -> t
@@ -94,41 +94,50 @@ module type S = sig
 
   val pp : Format.formatter -> t -> unit
   (** Output the result of {!to_string} on a formatter. *)
-
-  module Infix : sig
-    val (+) : t -> t -> t
-    (** Addition.  See {!add}. *)
-
-    val (-) : t -> t -> t
-    (** Subtraction.  See {!sub}.*)
-
-    val ( * ) : t -> t -> t
-    (** Multiplication.  See {!mul}.*)
-
-    val (/) : t -> t -> t
-    (** Division.  See {!div}.*)
-
-    val (mod) : t -> t -> t
-    (** Integer remainder.  See {!rem}. *)
-
-    val (land) : t -> t -> t
-    (** Bitwise logical and.  See {!logand}. *)
-
-    val (lor) : t -> t -> t
-    (** Bitwise logical or.  See {!logor}. *)
-
-    val (lxor) : t -> t -> t
-    (** Bitwise logical exclusive or.  See {!logxor}. *)
-
-    val (lsl) : t -> int -> t
-    (** [x lsl y] shifts [x] to the left by [y] bits.  See {!shift_left}. *)
-
-    val (lsr) : t -> int -> t
-    (** [x lsr y] shifts [x] to the right by [y] bits.  See {!shift_right}. *)
-  end
-(** Infix names for the unsigned integer operations. *)
 end
 (** Unsigned integer operations. *)
+
+module type Infixes = sig
+  type t
+
+  val (+) : t -> t -> t
+  (** Addition.  See {!add}. *)
+
+  val (-) : t -> t -> t
+  (** Subtraction.  See {!sub}.*)
+
+  val ( * ) : t -> t -> t
+  (** Multiplication.  See {!mul}.*)
+
+  val (/) : t -> t -> t
+  (** Division.  See {!div}.*)
+
+  val (mod) : t -> t -> t
+  (** Integer remainder.  See {!rem}. *)
+
+  val (land) : t -> t -> t
+  (** Bitwise logical and.  See {!logand}. *)
+
+  val (lor) : t -> t -> t
+  (** Bitwise logical or.  See {!logor}. *)
+
+  val (lxor) : t -> t -> t
+  (** Bitwise logical exclusive or.  See {!logxor}. *)
+
+  val (lsl) : t -> int -> t
+  (** [x lsl y] shifts [x] to the left by [y] bits.  See {!shift_left}. *)
+
+  val (lsr) : t -> int -> t
+  (** [x lsr y] shifts [x] to the right by [y] bits.  See {!shift_right}. *)
+end
+(** Infix names for the unsigned integer operations. *)
+
+module type S = sig
+  include Operations
+
+  module Infix : Infixes with type t := t
+end
+(** Unsigned integer operations and operators. *)
 
 module UChar : S with type t = private int
 (** Unsigned char type and operations. *)


### PR DESCRIPTION
My motivation picking this up is using ocaml-integers in a duniverse, meaning I'm even more sensitive to spurious compiler warnings than my over-washed hands are at present to soap...

I have:
 - (hopefully) fixed #16 by splitting `Unsigned.S` into two module types with `Unsigned.S` then using a destructive substitution to get rid of `type t` inside `S.Infix`. This means that `Unsigned.Operations` and `Unsigned.Infixes` can be used separately when defining `Signed.S` which allows `S.Infix.(asr)` to be added. I _think_ this is all sound and I'm _certain_ you'll tell me if it's not 🙂 The documentation is already not that great for `include` signatures - something which I think is improving in odoc (@jonludlam?)
- I've added a very simple pre-processor which erases lines ending `(* SHIM *)` if run on OCaml 4.03+ which removes warnings about unused `equal` functions in `Signed`.
- I've added a dependency on stdlib-shims to allow compiling on 4.08+ without a deprecation warning. The alternative would be to use the pre-processor added for `Int32.equal` and `Int64.equal` shimming on 4.02.3 to rewrite occurrences of `Pervasives.` but that's potentially quite brittle.