### PR TITLE
Add stdlib-compatible string parsing

### DIFF
--- a/src/unsigned_stubs.c
+++ b/src/unsigned_stubs.c
@@ -71,7 +71,7 @@ static int parse_digit(char c)
       }                                                                      \
     }                                                                        \
                                                                              \
-    max_prefix = ((TYPE(BITS)) 1 << (BITS - 1)) / base;                      \
+    max_prefix = ((TYPE(BITS)) -1) / base;                                   \
                                                                              \
     d = parse_digit(*pos);                                                   \
     if (d < 0 || d >= base) {                                                \

--- a/src/unsigned_stubs.c
+++ b/src/unsigned_stubs.c
@@ -22,6 +22,18 @@
 
 #include "ocaml_integers.h"
 
+static int parse_digit(char c)
+{
+  if (c >= '0' && c <= '9')
+    return c - '0';
+  else if (c >= 'A' && c <= 'F')
+    return c - 'A' + 10;
+  else if (c >= 'a' && c <= 'f')
+    return c - 'a' + 10;
+  else
+    return -1;
+}
+
 #define Uint_custom_val(SIZE, V) Uint_custom_val_(SIZE, V)
 #define Uint_custom_val_(SIZE, V) \
   (*(uint ## SIZE ## _t *)(Data_custom_val(V)))
@@ -148,11 +160,51 @@
   /* of_string : string -> t */                                              \
   value integers_uint ## BITS ## _of_string(value a)                         \
   {                                                                          \
-    TYPE(BITS) u;                                                            \
-    if (sscanf(String_val(a), "%" SCNu ## BITS , &u) != 1)                   \
+    TYPE(BITS) u, max_prefix;                                                \
+    const char *pos = String_val(a);                                         \
+    int base = 10, d;                                                        \
+                                                                             \
+    /* Strip a leading + sign, if given */                                   \
+    if (*pos == '+') pos++;                                                  \
+    if (*pos == '0') {                                                       \
+      switch (pos[1]) {                                                      \
+        case 'x': case 'X':                                                  \
+          base = 16; pos += 2; break;                                        \
+        case 'o': case 'O':                                                  \
+          base = 8; pos += 2; break;                                         \
+        case 'b': case 'B':                                                  \
+          base = 2; pos += 2; break;                                         \
+        case 'u': case 'U': /* Unsigned prefix. No-op for unsigned types */  \
+          pos += 2; break;                                                   \
+      }                                                                      \
+    }                                                                        \
+                                                                             \
+    max_prefix = ((TYPE(BITS)) 1 << (BITS - 1)) / base;                      \
+                                                                             \
+    d = parse_digit(*pos);                                                   \
+    if (d < 0 || d >= base) {                                                \
       caml_failwith("int_of_string");                                        \
-    else                                                                     \
-      return integers_copy_uint ## BITS (u);                                 \
+    }                                                                        \
+    u = (TYPE(BITS)) d;                                                      \
+    pos++;                                                                   \
+                                                                             \
+    for (;; pos++) {                                                         \
+      if (*pos == '_') continue;                                             \
+      d = parse_digit(*pos);                                                 \
+      /* Halt if the digit isn't valid (or this is the string terminator) */ \
+      if (d < 0 || d >= base) break;                                         \
+      /* Check that we can add another digit */                              \
+      if (u > max_prefix) break;                                             \
+      u = d + u * base;                                                      \
+      /* Check for overflow */                                               \
+      if (u < (TYPE(BITS)) d) break;                                         \
+    }                                                                        \
+                                                                             \
+    if (pos != String_val(a) + caml_string_length(a)){                       \
+      caml_failwith("int_of_string");                                        \
+    }                                                                        \
+                                                                             \
+    return integers_copy_uint ## BITS (u);                                   \
   }                                                                          \
                                                                              \
   /* to_string : t -> string */                                              \
@@ -175,11 +227,51 @@
   /* of_string : string -> t */                                              \
   value integers_uint ## BITS ## _of_string(value a)                         \
   {                                                                          \
-    TYPE(BITS) u;                                                            \
-    if (sscanf(String_val(a), "%" SCNu ## BITS , &u) != 1)                   \
+    TYPE(BITS) u, max_prefix;                                                \
+    const char *pos = String_val(a);                                         \
+    int base = 10, d;                                                        \
+                                                                             \
+    /* Strip a leading + sign, if given */                                   \
+    if (*pos == '+') pos++;                                                  \
+    if (*pos == '0') {                                                       \
+      switch (pos[1]) {                                                      \
+        case 'x': case 'X':                                                  \
+          base = 16; pos += 2; break;                                        \
+        case 'o': case 'O':                                                  \
+          base = 8; pos += 2; break;                                         \
+        case 'b': case 'B':                                                  \
+          base = 2; pos += 2; break;                                         \
+        case 'u': case 'U': /* Unsigned prefix. No-op for unsigned types */  \
+          pos += 2; break;                                                   \
+      }                                                                      \
+    }                                                                        \
+                                                                             \
+    max_prefix = ((TYPE(BITS)) 1 << (BITS - 1)) / base;                      \
+                                                                             \
+    d = parse_digit(*pos);                                                   \
+    if (d < 0 || d >= base) {                                                \
       caml_failwith("int_of_string");                                        \
-    else                                                                     \
-      return Integers_val_uint ## BITS(u);                                   \
+    }                                                                        \
+    u = (TYPE(BITS)) d;                                                      \
+    pos++;                                                                   \
+                                                                             \
+    for (;; pos++) {                                                         \
+      if (*pos == '_') continue;                                             \
+      d = parse_digit(*pos);                                                 \
+      /* Halt if the digit isn't valid (or this is the string terminator) */ \
+      if (d < 0 || d >= base) break;                                         \
+      /* Check that we can add another digit */                              \
+      if (u > max_prefix) break;                                             \
+      u = d + u * base;                                                      \
+      /* Check for overflow */                                               \
+      if (u < (TYPE(BITS)) d) break;                                         \
+    }                                                                        \
+                                                                             \
+    if (pos != String_val(a) + caml_string_length(a)){                       \
+      caml_failwith("int_of_string");                                        \
+    }                                                                        \
+                                                                             \
+    return Integers_val_uint ## BITS(u);                                     \
   }                                                                          \
                                                                              \
   /* to_string : t -> string */                                              \


### PR DESCRIPTION
This PR changes the parsing to be compatible with the integer parsing used by `int_of_string`, `Int64.of_string`, etc. in the OCaml standard library. This adds support for
* bases other than 10 (`0x` for 16, `0o` for 8, `0b` for 2, `0u` for 'unsigned')
  - `0xF`, `0o7`, `0b10`, etc. were previously interpreted as `0`
* `_` spacers within the number
  -  `1_000_000` was interpreted as `1`, now interpreted as `1000000`

This also rejects more inputs with errors, to be better aligned with the stdlib:
* `   1` was interpreted as `1`, now raises an error
* `1.2` was interpreted as `1`, now raises an error
* `99999999999999999999999999999999999` was interpreted as `max_int`, now raises an error
* `-99999999999999999999999999999999999` was interpreted as `max_int`, now raises an error
* `-15` was interpreted as `max_int - 14`, now raises an error

------

Test run:
```ocaml
$ dune utop src/
───────────────┬─────────────────────────────────────────────────────────────┬────────────────
               │ Welcome to utop version 2.7.0 (using OCaml version 4.11.2)! │
               └─────────────────────────────────────────────────────────────┘
Findlib has been successfully loaded. Additional directives:
  #require "package";;      to load a package
  #list;;                   to list the available packages
  #camlp4o;;                to load camlp4 (standard syntax)
  #camlp4r;;                to load camlp4 (revised syntax)
  #predicates "p,q,...";;   to set these predicates
  Topfind.reset();;         to force that packages will be reloaded
  #thread;;                 to enable threads


Type #utop_help for help about using utop.

─( 18:54:46 )─< command 0 >────────────────────────────────────────────────────{ counter: 0 }─
utop # open Unsigned;;
─( 18:54:46 )─< command 1 >────────────────────────────────────────────────────{ counter: 0 }─
utop # #install_printer UInt64.pp;;
─( 18:54:49 )─< command 2 >────────────────────────────────────────────────────{ counter: 0 }─
utop # #install_printer UInt32.pp;;
─( 18:54:49 )─< command 3 >────────────────────────────────────────────────────{ counter: 0 }─
utop # #install_printer UInt16.pp;;
─( 18:54:49 )─< command 4 >────────────────────────────────────────────────────{ counter: 0 }─
utop # #install_printer UInt8.pp;;
─( 18:54:50 )─< command 5 >────────────────────────────────────────────────────{ counter: 0 }─
utop # UInt8.of_string "0";;
- : uint8 = 0
─( 18:54:50 )─< command 6 >────────────────────────────────────────────────────{ counter: 0 }─
utop # UInt8.of_string "1";;
- : uint8 = 1
─( 18:54:50 )─< command 7 >────────────────────────────────────────────────────{ counter: 0 }─
utop # UInt8.of_string "+1";;
- : uint8 = 1
─( 18:54:50 )─< command 8 >────────────────────────────────────────────────────{ counter: 0 }─
utop # UInt8.of_string "-1";;
Exception: Failure "int_of_string".
─( 18:54:50 )─< command 9 >────────────────────────────────────────────────────{ counter: 0 }─
utop # UInt8.of_string "10";;
- : uint8 = 10
─( 18:54:50 )─< command 10 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt8.of_string "0x10";;
- : uint8 = 16
─( 18:54:50 )─< command 11 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt8.of_string "0o10";;
- : uint8 = 8
─( 18:54:50 )─< command 12 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt8.of_string "0b10";;
- : uint8 = 2
─( 18:54:50 )─< command 13 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt8.of_string "256";;
Exception: Failure "int_of_string".
─( 18:54:50 )─< command 14 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt8.of_string "65535";;
Exception: Failure "int_of_string".
─( 18:54:50 )─< command 15 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt8.of_string "4294967295";;
Exception: Failure "int_of_string".
─( 18:54:50 )─< command 16 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt8.of_string "18446744073709551615";;
Exception: Failure "int_of_string".
─( 18:54:50 )─< command 17 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt8.of_string "99999999999999999999999999999999999";;
Exception: Failure "int_of_string".
─( 18:54:50 )─< command 18 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt16.of_string "0";;
- : uint16 = 0
─( 18:54:50 )─< command 19 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt16.of_string "1";;
- : uint16 = 1
─( 18:54:50 )─< command 20 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt16.of_string "+1";;
- : uint16 = 1
─( 18:54:50 )─< command 21 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt16.of_string "-1";;
Exception: Failure "int_of_string".
─( 18:54:50 )─< command 22 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt16.of_string "10";;
- : uint16 = 10
─( 18:54:50 )─< command 23 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt16.of_string "0x10";;
- : uint16 = 16
─( 18:54:50 )─< command 24 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt16.of_string "0o10";;
- : uint16 = 8
─( 18:54:50 )─< command 25 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt16.of_string "0b10";;
- : uint16 = 2
─( 18:54:50 )─< command 26 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt16.of_string "256";;
- : uint16 = 256
─( 18:54:50 )─< command 27 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt16.of_string "65535";;
Exception: Failure "int_of_string".
─( 18:54:50 )─< command 28 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt16.of_string "4294967295";;
Exception: Failure "int_of_string".
─( 18:54:50 )─< command 29 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt16.of_string "18446744073709551615";;
Exception: Failure "int_of_string".
─( 18:54:51 )─< command 30 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt16.of_string "99999999999999999999999999999999999";;
Exception: Failure "int_of_string".
─( 18:54:51 )─< command 31 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt32.of_string "0";;
- : uint32 = 0
─( 18:54:51 )─< command 32 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt32.of_string "1";;
- : uint32 = 1
─( 18:54:51 )─< command 33 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt32.of_string "+1";;
- : uint32 = 1
─( 18:54:51 )─< command 34 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt32.of_string "-1";;
Exception: Failure "int_of_string".
─( 18:54:51 )─< command 35 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt32.of_string "10";;
- : uint32 = 10
─( 18:54:51 )─< command 36 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt32.of_string "0x10";;
- : uint32 = 16
─( 18:54:51 )─< command 37 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt32.of_string "0o10";;
- : uint32 = 8
─( 18:54:51 )─< command 38 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt32.of_string "0b10";;
- : uint32 = 2
─( 18:54:51 )─< command 39 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt32.of_string "256";;
- : uint32 = 256
─( 18:54:51 )─< command 40 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt32.of_string "65535";;
- : uint32 = 65535
─( 18:54:51 )─< command 41 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt32.of_string "4294967295";;
Exception: Failure "int_of_string".
─( 18:54:51 )─< command 42 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt32.of_string "18446744073709551615";;
Exception: Failure "int_of_string".
─( 18:54:51 )─< command 43 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt32.of_string "99999999999999999999999999999999999";;
Exception: Failure "int_of_string".
─( 18:54:51 )─< command 44 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt64.of_string "0";;
- : uint64 = 0
─( 18:54:51 )─< command 45 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt64.of_string "1";;
- : uint64 = 1
─( 18:54:51 )─< command 46 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt64.of_string "+1";;
- : uint64 = 1
─( 18:54:51 )─< command 47 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt64.of_string "-1";;
Exception: Failure "int_of_string".
─( 18:54:51 )─< command 48 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt64.of_string "10";;
- : uint64 = 10
─( 18:54:51 )─< command 49 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt64.of_string "0x10";;
- : uint64 = 16
─( 18:54:51 )─< command 50 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt64.of_string "0o10";;
- : uint64 = 8
─( 18:54:51 )─< command 51 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt64.of_string "0b10";;
- : uint64 = 2
─( 18:54:52 )─< command 52 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt64.of_string "256";;
- : uint64 = 256
─( 18:54:52 )─< command 53 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt64.of_string "65535";;
- : uint64 = 65535
─( 18:54:52 )─< command 54 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt64.of_string "4294967295";;
- : uint64 = 4294967295
─( 18:54:52 )─< command 55 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt64.of_string "18446744073709551615";;
Exception: Failure "int_of_string".
─( 18:54:52 )─< command 56 >───────────────────────────────────────────────────{ counter: 0 }─
utop # UInt64.of_string "99999999999999999999999999999999999";;
Exception: Failure "int_of_string".
─( 18:54:52 )─< command 57 >───────────────────────────────────────────────────{ counter: 0 }─
utop #
```