### PR TITLE
restore dll support for cygwin64 / newer binutils versions (mingw64)

### DIFF
--- a/src/ocaml_integers.h
+++ b/src/ocaml_integers.h
@@ -12,58 +12,16 @@
 
 #include <stdint.h>
 
-#define UINT_DECLS(BITS)                                                    \
-  extern value integers_copy_uint ## BITS(uint ## BITS ## _t u);            \
-  /* uintX_add : t -> t -> t */                                             \
-  extern value integers_uint ## BITS ## _ ## add(value a, value b);         \
-  /* uintX_sub : t -> t -> t */                                             \
-  extern value integers_uint ## BITS ## _ ## sub(value a, value b);         \
-  /* uintX_mul : t -> t -> t */                                             \
-  extern value integers_uint ## BITS ## _ ## mul(value a, value b);         \
-  /* uintX_div : t -> t -> t */                                             \
-  extern value integers_uint ## BITS ## _ ## div(value a, value b);         \
-  /* uintX_rem : t -> t -> t */                                             \
-  extern value integers_uint ## BITS ## _ ## rem(value a, value b);         \
-  /* uintX_logand : t -> t -> t */                                          \
-  extern value integers_uint ## BITS ## _ ## logand(value a, value b);      \
-  /* uintX_logor : t -> t -> t */                                           \
-  extern value integers_uint ## BITS ## _ ## logor(value a, value b);       \
-  /* uintX_logxor : t -> t -> t */                                          \
-  extern value integers_uint ## BITS ## _ ## logxor(value a, value b);      \
-  /* uintX_shift_left : t -> t -> t */                                      \
-  extern value integers_uint ## BITS ## _ ## shift_left(value a, value b);  \
-  /* uintX_shift_right : t -> t -> t */                                     \
-  extern value integers_uint ## BITS ## _ ## shift_right(value a, value b); \
-  /* of_int : int -> t */                                                   \
-  extern value integers_uint ## BITS ## _of_int(value a);                   \
-  /* to_int : t -> int */                                                   \
-  extern value integers_uint ## BITS ## _to_int(value a);                   \
-  /* of_string : string -> t */                                             \
-  extern value integers_uint ## BITS ## _of_string(value a);                \
-  /* to_string : t -> string */                                             \
-  extern value integers_uint ## BITS ## _to_string(value a);                \
-  /* max : unit -> t */                                                     \
-  extern value integers_uint ## BITS ## _max(value a);
-
-#define UINT_SMALL_DECLS(BITS)                                              \
-  /* of_string : string -> t */                                             \
-  extern value integers_uint ## BITS ## _of_string(value a);                \
-  /* to_string : t -> string */                                             \
-  extern value integers_uint ## BITS ## _to_string(value a);                \
-  /* max : unit -> t */                                                     \
-  extern value integers_uint ## BITS ## _max(value a);
-
-UINT_SMALL_DECLS(8)
-UINT_SMALL_DECLS(16)
-UINT_DECLS(32)
-UINT_DECLS(64)
-
-/* X_size : unit -> int */
-extern value integers_size_t_size (value _);
-extern value integers_ushort_size (value _);
-extern value integers_uint_size (value _);
-extern value integers_ulong_size (value _);
-extern value integers_ulonglong_size (value _);
+#ifndef OCAML_INTEGERS_INTERNAL
+#ifdef __cplusplus
+extern "C" {
+#endif
+CAMLextern value integers_copy_uint32(uint32_t u);
+CAMLextern value integers_copy_uint64(uint64_t u);
+#ifdef __cplusplus
+}
+#endif
+#endif
 
 #define Integers_val_uint8(t) ((Val_int((uint8_t)t)))
 #define Integers_val_uint16(t) ((Val_int((uint16_t)t)))

--- a/src/unsigned_stubs.c
+++ b/src/unsigned_stubs.c
@@ -20,7 +20,62 @@
 #include <limits.h>
 #include <stdio.h>
 
+#define OCAML_INTEGERS_INTERNAL 1
 #include "ocaml_integers.h"
+
+#define UINT_DECLS(BITS)                                                    \
+  extern value integers_copy_uint ## BITS(uint ## BITS ## _t u);            \
+  /* uintX_add : t -> t -> t */                                             \
+  extern value integers_uint ## BITS ## _ ## add(value a, value b);         \
+  /* uintX_sub : t -> t -> t */                                             \
+  extern value integers_uint ## BITS ## _ ## sub(value a, value b);         \
+  /* uintX_mul : t -> t -> t */                                             \
+  extern value integers_uint ## BITS ## _ ## mul(value a, value b);         \
+  /* uintX_div : t -> t -> t */                                             \
+  extern value integers_uint ## BITS ## _ ## div(value a, value b);         \
+  /* uintX_rem : t -> t -> t */                                             \
+  extern value integers_uint ## BITS ## _ ## rem(value a, value b);         \
+  /* uintX_logand : t -> t -> t */                                          \
+  extern value integers_uint ## BITS ## _ ## logand(value a, value b);      \
+  /* uintX_logor : t -> t -> t */                                           \
+  extern value integers_uint ## BITS ## _ ## logor(value a, value b);       \
+  /* uintX_logxor : t -> t -> t */                                          \
+  extern value integers_uint ## BITS ## _ ## logxor(value a, value b);      \
+  /* uintX_shift_left : t -> t -> t */                                      \
+  extern value integers_uint ## BITS ## _ ## shift_left(value a, value b);  \
+  /* uintX_shift_right : t -> t -> t */                                     \
+  extern value integers_uint ## BITS ## _ ## shift_right(value a, value b); \
+  /* of_int : int -> t */                                                   \
+  extern value integers_uint ## BITS ## _of_int(value a);                   \
+  /* to_int : t -> int */                                                   \
+  extern value integers_uint ## BITS ## _to_int(value a);                   \
+  /* of_string : string -> t */                                             \
+  extern value integers_uint ## BITS ## _of_string(value a);                \
+  /* to_string : t -> string */                                             \
+  extern value integers_uint ## BITS ## _to_string(value a);                \
+  /* max : unit -> t */                                                     \
+  extern value integers_uint ## BITS ## _max(value a);
+
+#define UINT_SMALL_DECLS(BITS)                                              \
+  /* of_string : string -> t */                                             \
+  extern value integers_uint ## BITS ## _of_string(value a);                \
+  /* to_string : t -> string */                                             \
+  extern value integers_uint ## BITS ## _to_string(value a);                \
+  /* max : unit -> t */                                                     \
+  extern value integers_uint ## BITS ## _max(value a);
+
+UINT_SMALL_DECLS(8)
+UINT_SMALL_DECLS(16)
+UINT_DECLS(32)
+UINT_DECLS(64)
+
+/* X_size : unit -> int */
+extern value integers_size_t_size (value _);
+extern value integers_ushort_size (value _);
+extern value integers_uint_size (value _);
+extern value integers_ulong_size (value _);
+extern value integers_ulonglong_size (value _);
+
 
 static int parse_digit(char c)
 {


### PR DESCRIPTION
`CAMLextern` must now be used for functions used by foreign stub code.
For details: https://github.com/ocaml/ocaml/pull/9927

Since this makes it more complicated to use, I took this as an opportunity to shorten the header and remove all functions from it that are only used internally by integers/ctypes.

A similar pull request for ctypes will follow.