### PR TITLE
Remove OCaml 4.08 (no longer in opam-repository) from CI configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,9 @@ jobs:
           - macos-latest
 
         ocaml-compiler:
-          - 4.08
           - 4.14
           - 5.2
           - 5.3
-
-        exclude:
-          - os: macos-latest
-            ocaml-compiler: 4.08
-          - os: windows-latest
-            ocaml-compiler: 4.08
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
OCaml versions below 4.11 are no longer available in opam-repository.  The details are here:
- https://discuss.ocaml.org/t/archival-ann-raising-the-ocaml-lower-bound-to-4-11-0-for-opam-repository
- https://github.com/ocaml/opam-repository-archive/pull/35