### PR TITLE
Add lnot "operator"

### DIFF
--- a/src/signed.ml
+++ b/src/signed.ml
@@ -38,6 +38,7 @@ module type Basics = sig
   val mul : t -> t -> t
   val div : t -> t -> t
   val rem : t -> t -> t
+  val lognot : t -> t
   val logand : t -> t -> t
   val logor : t -> t -> t
   val logxor : t -> t -> t
@@ -54,6 +55,7 @@ struct
   let ( * ) = mul
   let (/) = div
   let (mod) = rem
+  let lnot = lognot
   let (land) = logand
   let (lor) = logor
   let (lxor) = logxor

--- a/src/unsigned.ml
+++ b/src/unsigned.ml
@@ -59,6 +59,7 @@ module type Infix = sig
   val ( * ) : t -> t -> t
   val (/) : t -> t -> t
   val (mod) : t -> t -> t
+  val lnot : t -> t
   val (land) : t -> t -> t
   val (lor) : t -> t -> t
   val (lxor) : t -> t -> t
@@ -72,22 +73,6 @@ module type S = sig
   include Extras with type t := t
 
   module Infix : Infix with type t := t
-end
-
-
-module MakeInfix (B : Basics) =
-struct
-  open B
-  let (+) = add
-  let (-) = sub
-  let ( * ) = mul
-  let (/) = div
-  let (mod) = rem
-  let (land) = logand
-  let (lor) = logor
-  let (lxor) = logxor
-  let (lsl) = shift_left
-  let (lsr) = shift_right
 end
 
 
@@ -106,6 +91,24 @@ struct
   let of_string_opt (s : string) = try Some (of_string s) with Failure _ -> None
   let pp fmt x = Format.fprintf fmt "%s" (to_string x)
   let pp_hex fmt x = Format.fprintf fmt "%s" (to_hexstring x)
+end
+
+
+module MakeInfix (B : Basics) =
+struct
+  open B
+  open Extras(B)
+  let (+) = add
+  let (-) = sub
+  let ( * ) = mul
+  let (/) = div
+  let (mod) = rem
+  let lnot = lognot
+  let (land) = logand
+  let (lor) = logor
+  let (lxor) = logxor
+  let (lsl) = shift_left
+  let (lsr) = shift_right
 end
 
 external format_int : string -> int -> string = "caml_format_int"

--- a/src/unsigned.mli
+++ b/src/unsigned.mli
@@ -26,6 +26,9 @@ module type Infix = sig
   val (mod) : t -> t -> t
   (** Integer remainder.  See {!rem}. *)
 
+  val lnot : t -> t
+  (** Bitwise logical negation.  See {!lognot}. *)
+
   val (land) : t -> t -> t
   (** Bitwise logical and.  See {!logand}. *)
 


### PR DESCRIPTION
Add the `lnot` "operator", so after "open Infix" we can write e.g.

```
a land lnot b
```

Although `lnot` is technically just a function and not an operator, it is practically used like an operator and thus should be part of the "open Infix" convenience, as its absence is a lot more surprising than its presence will be.